### PR TITLE
Add in-memory param cache

### DIFF
--- a/src/tui/actions.ts
+++ b/src/tui/actions.ts
@@ -2,6 +2,7 @@ import type { Command } from "../../generated/index.ts";
 import { ClientError } from "../lib/client.ts";
 import type { ErrorInfo } from "./state.ts";
 import type { TuiContext } from "./types.ts";
+import { saveArgsToCache } from "./args-cache.ts";
 import { updateStatusBar, updateView } from "./view.ts";
 
 export async function executeCommand(context: TuiContext, cmd: Command): Promise<void> {
@@ -25,6 +26,7 @@ export async function executeCommand(context: TuiContext, cmd: Command): Promise
 
   try {
     const args: Record<string, unknown> = { ...state.collectedArgs };
+    saveArgsToCache(context.argsCache, cmd, state.collectedArgs);
     const result = await cmd.handler(client, args);
 
     if (result && typeof result === "object" && "results" in result) {

--- a/src/tui/actions.ts
+++ b/src/tui/actions.ts
@@ -26,7 +26,7 @@ export async function executeCommand(context: TuiContext, cmd: Command): Promise
 
   try {
     const args: Record<string, unknown> = { ...state.collectedArgs };
-    saveArgsToCache(context.argsCache, cmd, state.collectedArgs);
+    saveArgsToCache(context.argsCache, context.argsCacheScopeKey, cmd, state.collectedArgs);
     const result = await cmd.handler(client, args);
 
     if (result && typeof result === "object" && "results" in result) {

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -21,6 +21,7 @@ import { createErrorPanel } from "./components/error.ts";
 import type { TuiContext, UiComponents } from "./types.ts";
 import { setupHandlers } from "./handlers.ts";
 import { updateConnectionDisplay, fetchConnectionInfo } from "./connection.ts";
+import { createArgsCache } from "./args-cache.ts";
 import { updateStatusBar, updateView } from "./view.ts";
 
 // Initialize the TUI
@@ -82,6 +83,7 @@ export async function startTui(profileName?: string): Promise<void> {
     client,
     state,
     components,
+    argsCache: createArgsCache(),
     currentProfileName: profileName,
   };
 

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -21,7 +21,7 @@ import { createErrorPanel } from "./components/error.ts";
 import type { TuiContext, UiComponents } from "./types.ts";
 import { setupHandlers } from "./handlers.ts";
 import { updateConnectionDisplay, fetchConnectionInfo } from "./connection.ts";
-import { createArgsCache } from "./args-cache.ts";
+import { createArgsCache, getConnectionScopeKey } from "./args-cache.ts";
 import { updateStatusBar, updateView } from "./view.ts";
 
 // Initialize the TUI
@@ -84,6 +84,7 @@ export async function startTui(profileName?: string): Promise<void> {
     state,
     components,
     argsCache: createArgsCache(),
+    argsCacheScopeKey: getConnectionScopeKey(config.connectionToken),
     currentProfileName: profileName,
   };
 

--- a/src/tui/args-cache.ts
+++ b/src/tui/args-cache.ts
@@ -9,6 +9,20 @@ export function createArgsCache(): ArgsCache {
   return new Map();
 }
 
+function scopedCacheKey(scopeKey: string, commandName: string): string {
+  return `${scopeKey}\0${commandName}`;
+}
+
+/** Scope key for the active connection token (empty when none is configured). */
+export function getConnectionScopeKey(connectionToken?: string): string {
+  return connectionToken ?? "";
+}
+
+/** Connection-scoped commands use the token; account-level commands use global scope. */
+export function resolveArgsCacheScopeKey(cmd: Command, connectionScopeKey: string): string {
+  return cmd.requiresConnectionToken ? connectionScopeKey : "";
+}
+
 function isCacheableArg(arg: CommandArg): boolean {
   return !UNCACHEABLE_ARG_NAMES.has(arg.name);
 }
@@ -45,8 +59,13 @@ function isValidCachedValue(arg: CommandArg, value: unknown): boolean {
   return true;
 }
 
-export function getCachedArgs(cache: ArgsCache, cmd: Command): Record<string, unknown> {
-  const stored = cache.get(cmd.name);
+export function getCachedArgs(
+  cache: ArgsCache,
+  connectionScopeKey: string,
+  cmd: Command,
+): Record<string, unknown> {
+  const scopeKey = resolveArgsCacheScopeKey(cmd, connectionScopeKey);
+  const stored = cache.get(scopedCacheKey(scopeKey, cmd.name));
   if (!stored) {
     return {};
   }
@@ -67,6 +86,7 @@ export function getCachedArgs(cache: ArgsCache, cmd: Command): Record<string, un
 
 export function saveArgsToCache(
   cache: ArgsCache,
+  connectionScopeKey: string,
   cmd: Command,
   collectedArgs: Record<string, unknown>,
 ): void {
@@ -80,20 +100,25 @@ export function saveArgsToCache(
     toStore[name] = value;
   }
 
+  const scopeKey = resolveArgsCacheScopeKey(cmd, connectionScopeKey);
+  const key = scopedCacheKey(scopeKey, cmd.name);
+
   if (Object.keys(toStore).length === 0) {
-    cache.delete(cmd.name);
+    cache.delete(key);
     return;
   }
 
-  cache.set(cmd.name, toStore);
+  cache.set(key, toStore);
 }
 
-export function clearCachedArgs(cache: ArgsCache, commandName: string): void {
-  cache.delete(commandName);
+export function clearCachedArgs(cache: ArgsCache, connectionScopeKey: string, cmd: Command): void {
+  const scopeKey = resolveArgsCacheScopeKey(cmd, connectionScopeKey);
+  cache.delete(scopedCacheKey(scopeKey, cmd.name));
 }
 
-export function hasCachedArgs(cache: ArgsCache, commandName: string): boolean {
-  return cache.has(commandName);
+export function hasCachedArgs(cache: ArgsCache, connectionScopeKey: string, cmd: Command): boolean {
+  const scopeKey = resolveArgsCacheScopeKey(cmd, connectionScopeKey);
+  return cache.has(scopedCacheKey(scopeKey, cmd.name));
 }
 
 export function getEditableArgs(cmd: Command): CommandArg[] {

--- a/src/tui/args-cache.ts
+++ b/src/tui/args-cache.ts
@@ -1,0 +1,101 @@
+import type { Command, CommandArg } from "../../generated/index.ts";
+
+export type ArgsCache = Map<string, Record<string, unknown>>;
+
+/** Args that are one-shot tokens and must not be reused across runs. */
+const UNCACHEABLE_ARG_NAMES = new Set(["cursor"]);
+
+export function createArgsCache(): ArgsCache {
+  return new Map();
+}
+
+function isCacheableArg(arg: CommandArg): boolean {
+  return !UNCACHEABLE_ARG_NAMES.has(arg.name);
+}
+
+function isValidCachedValue(arg: CommandArg, value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  if (arg.enum && arg.enum.length > 0) {
+    const asString =
+      typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+        ? String(value)
+        : null;
+    return asString !== null && arg.enum.includes(asString);
+  }
+
+  if (arg.type === "number") {
+    return typeof value === "number" && !Number.isNaN(value);
+  }
+
+  if (arg.type === "boolean") {
+    return typeof value === "boolean";
+  }
+
+  if (arg.type === "array") {
+    return Array.isArray(value);
+  }
+
+  if (arg.type === "object") {
+    return typeof value === "object" && !Array.isArray(value);
+  }
+
+  return true;
+}
+
+export function getCachedArgs(cache: ArgsCache, cmd: Command): Record<string, unknown> {
+  const stored = cache.get(cmd.name);
+  if (!stored) {
+    return {};
+  }
+
+  const argByName = new Map(cmd.args.map((arg) => [arg.name, arg]));
+  const restored: Record<string, unknown> = {};
+
+  for (const [name, value] of Object.entries(stored)) {
+    const arg = argByName.get(name);
+    if (!arg || !isCacheableArg(arg) || !isValidCachedValue(arg, value)) {
+      continue;
+    }
+    restored[name] = value;
+  }
+
+  return restored;
+}
+
+export function saveArgsToCache(
+  cache: ArgsCache,
+  cmd: Command,
+  collectedArgs: Record<string, unknown>,
+): void {
+  const cacheableNames = new Set(cmd.args.filter(isCacheableArg).map((arg) => arg.name));
+
+  const toStore: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(collectedArgs)) {
+    if (!cacheableNames.has(name)) {
+      continue;
+    }
+    toStore[name] = value;
+  }
+
+  if (Object.keys(toStore).length === 0) {
+    cache.delete(cmd.name);
+    return;
+  }
+
+  cache.set(cmd.name, toStore);
+}
+
+export function clearCachedArgs(cache: ArgsCache, commandName: string): void {
+  cache.delete(commandName);
+}
+
+export function hasCachedArgs(cache: ArgsCache, commandName: string): boolean {
+  return cache.has(commandName);
+}
+
+export function getEditableArgs(cmd: Command): CommandArg[] {
+  return cmd.args;
+}

--- a/src/tui/args.ts
+++ b/src/tui/args.ts
@@ -26,8 +26,13 @@ export function shouldPromptForArgs(cmd: Command): boolean {
   return cmd.args.length > 0;
 }
 
-export function initArgsStateForCommand(state: AppState, cmd: Command, cache: ArgsCache): void {
-  state.collectedArgs = getCachedArgs(cache, cmd);
+export function initArgsStateForCommand(
+  state: AppState,
+  cmd: Command,
+  cache: ArgsCache,
+  scopeKey: string,
+): void {
+  state.collectedArgs = getCachedArgs(cache, scopeKey, cmd);
   state.optionalArgIndex = 0;
   state.editingOptionalArgName = null;
 
@@ -48,8 +53,13 @@ export function initArgsStateForCommand(state: AppState, cmd: Command, cache: Ar
   }
 }
 
-export function clearSavedArgsForCommand(state: AppState, cmd: Command, cache: ArgsCache): void {
-  clearCachedArgs(cache, cmd.name);
+export function clearSavedArgsForCommand(
+  state: AppState,
+  cmd: Command,
+  cache: ArgsCache,
+  scopeKey: string,
+): void {
+  clearCachedArgs(cache, scopeKey, cmd);
   state.collectedArgs = {};
   state.optionalArgIndex = 0;
   state.editingOptionalArgName = null;
@@ -192,6 +202,7 @@ export function buildOptionalArgsOptions(
   cmd: Command,
   state: AppState,
   cache: ArgsCache,
+  scopeKey: string,
 ): SelectOption[] {
   const options: SelectOption[] = [
     {
@@ -205,7 +216,7 @@ export function buildOptionalArgsOptions(
     options.push(buildArgSelectOption(arg, state));
   }
 
-  if (hasCachedArgs(cache, cmd.name)) {
+  if (hasCachedArgs(cache, scopeKey, cmd)) {
     options.push({
       name: "Clear saved values",
       description: "Forget cached inputs for this command (d)",
@@ -216,7 +227,12 @@ export function buildOptionalArgsOptions(
   return options;
 }
 
-export function updateArgsView(state: AppState, components: UiComponents, cache: ArgsCache): void {
+export function updateArgsView(
+  state: AppState,
+  components: UiComponents,
+  cache: ArgsCache,
+  scopeKey: string,
+): void {
   const cmd = state.selectedCommand;
   if (!cmd) return;
 
@@ -231,14 +247,14 @@ export function updateArgsView(state: AppState, components: UiComponents, cache:
   if (state.argsPhase === "required") {
     if (requiredArgs.length === 0) {
       state.argsPhase = "optional-list";
-      updateArgsView(state, components, cache);
+      updateArgsView(state, components, cache, scopeKey);
       return;
     }
 
     const currentArg = requiredArgs[state.currentArgIndex];
     if (!currentArg) {
       state.argsPhase = "optional-list";
-      updateArgsView(state, components, cache);
+      updateArgsView(state, components, cache, scopeKey);
       return;
     }
 
@@ -260,7 +276,7 @@ export function updateArgsView(state: AppState, components: UiComponents, cache:
 
     argLabel.content = buildOptionalListLabelContent({ requiredArgs, optionalArgs, state });
 
-    const options = buildOptionalArgsOptions(cmd, state, cache);
+    const options = buildOptionalArgsOptions(cmd, state, cache, scopeKey);
     optionalArgsSelect.options = options;
     optionalArgsSelect.visible = true;
 
@@ -276,7 +292,7 @@ export function updateArgsView(state: AppState, components: UiComponents, cache:
     if (!currentArg) {
       state.argsPhase = "optional-list";
       state.editingOptionalArgName = null;
-      updateArgsView(state, components, cache);
+      updateArgsView(state, components, cache, scopeKey);
       return;
     }
 

--- a/src/tui/args.ts
+++ b/src/tui/args.ts
@@ -2,8 +2,16 @@ import type { SelectOption } from "@opentui/core";
 import type { Command, CommandArg } from "../../generated/index.ts";
 import type { AppState } from "./state.ts";
 import type { UiComponents } from "./types.ts";
+import {
+  clearCachedArgs,
+  getCachedArgs,
+  getEditableArgs,
+  hasCachedArgs,
+  type ArgsCache,
+} from "./args-cache.ts";
 
 const SUBMIT_OPTION_VALUE = "__submit__";
+const CLEAR_SAVED_OPTION_VALUE = "__clear_saved__";
 const UNSET_OPTION_VALUE = "__unset__";
 
 export function getRequiredArgs(cmd: Command): CommandArg[] {
@@ -18,14 +26,37 @@ export function shouldPromptForArgs(cmd: Command): boolean {
   return cmd.args.length > 0;
 }
 
-export function initArgsStateForCommand(state: AppState, cmd: Command): void {
+export function initArgsStateForCommand(state: AppState, cmd: Command, cache: ArgsCache): void {
+  state.collectedArgs = getCachedArgs(cache, cmd);
+  state.optionalArgIndex = 0;
+  state.editingOptionalArgName = null;
+
+  const requiredArgs = getRequiredArgs(cmd);
+  if (requiredArgs.length === 0) {
+    state.argsPhase = "optional-list";
+    state.currentArgIndex = 0;
+    return;
+  }
+
+  const firstMissingIndex = requiredArgs.findIndex((arg) => !(arg.name in state.collectedArgs));
+  if (firstMissingIndex === -1) {
+    state.argsPhase = "optional-list";
+    state.currentArgIndex = requiredArgs.length - 1;
+  } else {
+    state.argsPhase = "required";
+    state.currentArgIndex = firstMissingIndex;
+  }
+}
+
+export function clearSavedArgsForCommand(state: AppState, cmd: Command, cache: ArgsCache): void {
+  clearCachedArgs(cache, cmd.name);
   state.collectedArgs = {};
-  state.currentArgIndex = 0;
   state.optionalArgIndex = 0;
   state.editingOptionalArgName = null;
 
   const requiredArgs = getRequiredArgs(cmd);
   state.argsPhase = requiredArgs.length > 0 ? "required" : "optional-list";
+  state.currentArgIndex = 0;
 }
 
 export function cancelArgsFlow(state: AppState): void {
@@ -48,7 +79,11 @@ export function getActiveArg(state: AppState): CommandArg | null {
   }
 
   if (state.argsPhase === "optional-edit" && state.editingOptionalArgName) {
-    return optionalArgs.find((arg) => arg.name === state.editingOptionalArgName) ?? null;
+    return (
+      requiredArgs.find((arg) => arg.name === state.editingOptionalArgName) ??
+      optionalArgs.find((arg) => arg.name === state.editingOptionalArgName) ??
+      null
+    );
   }
 
   return null;
@@ -137,11 +172,27 @@ function buildOptionalListLabelContent(params: {
     `Required: ${requiredSummary}`,
     `Optional: ${optionalSummary}`,
     "",
-    "Select an optional field to set, or choose Submit.",
+    "Select a field to edit, Submit to run, or Clear saved values.",
   ].join("\n");
 }
 
-export function buildOptionalArgsOptions(cmd: Command, state: AppState): SelectOption[] {
+function buildArgSelectOption(arg: CommandArg, state: AppState): SelectOption {
+  const hasValue = arg.name in state.collectedArgs;
+  const preview = hasValue ? formatCollectedArgValue(state.collectedArgs[arg.name]) : "";
+  const requiredSuffix = arg.required ? " (required)" : "";
+
+  return {
+    name: hasValue ? `${arg.name} ✓${requiredSuffix}` : `${arg.name}${requiredSuffix}`,
+    description: preview || arg.description || "",
+    value: arg.name,
+  };
+}
+
+export function buildOptionalArgsOptions(
+  cmd: Command,
+  state: AppState,
+  cache: ArgsCache,
+): SelectOption[] {
   const options: SelectOption[] = [
     {
       name: "Submit",
@@ -150,22 +201,22 @@ export function buildOptionalArgsOptions(cmd: Command, state: AppState): SelectO
     },
   ];
 
-  const optionalArgs = getOptionalArgs(cmd);
+  for (const arg of getEditableArgs(cmd)) {
+    options.push(buildArgSelectOption(arg, state));
+  }
 
-  for (const arg of optionalArgs) {
-    const hasValue = arg.name in state.collectedArgs;
-    const preview = hasValue ? formatCollectedArgValue(state.collectedArgs[arg.name]) : "";
+  if (hasCachedArgs(cache, cmd.name)) {
     options.push({
-      name: hasValue ? `${arg.name} ✓` : arg.name,
-      description: preview || arg.description || "",
-      value: arg.name,
+      name: "Clear saved values",
+      description: "Forget cached inputs for this command (d)",
+      value: CLEAR_SAVED_OPTION_VALUE,
     });
   }
 
   return options;
 }
 
-export function updateArgsView(state: AppState, components: UiComponents): void {
+export function updateArgsView(state: AppState, components: UiComponents, cache: ArgsCache): void {
   const cmd = state.selectedCommand;
   if (!cmd) return;
 
@@ -180,14 +231,14 @@ export function updateArgsView(state: AppState, components: UiComponents): void 
   if (state.argsPhase === "required") {
     if (requiredArgs.length === 0) {
       state.argsPhase = "optional-list";
-      updateArgsView(state, components);
+      updateArgsView(state, components, cache);
       return;
     }
 
     const currentArg = requiredArgs[state.currentArgIndex];
     if (!currentArg) {
       state.argsPhase = "optional-list";
-      updateArgsView(state, components);
+      updateArgsView(state, components, cache);
       return;
     }
 
@@ -209,7 +260,7 @@ export function updateArgsView(state: AppState, components: UiComponents): void 
 
     argLabel.content = buildOptionalListLabelContent({ requiredArgs, optionalArgs, state });
 
-    const options = buildOptionalArgsOptions(cmd, state);
+    const options = buildOptionalArgsOptions(cmd, state, cache);
     optionalArgsSelect.options = options;
     optionalArgsSelect.visible = true;
 
@@ -225,7 +276,7 @@ export function updateArgsView(state: AppState, components: UiComponents): void 
     if (!currentArg) {
       state.argsPhase = "optional-list";
       state.editingOptionalArgName = null;
-      updateArgsView(state, components);
+      updateArgsView(state, components, cache);
       return;
     }
 
@@ -279,7 +330,7 @@ function showArgEditor(state: AppState, components: UiComponents, arg: CommandAr
 
   argEnumSelect.visible = false;
   argInput.visible = true;
-  argInput.value = state.argsPhase === "optional-edit" ? stringifyExistingValue(existingValue) : "";
+  argInput.value = stringifyExistingValue(existingValue);
   argInput.focus();
 }
 
@@ -366,6 +417,10 @@ export function submitActiveArg(state: AppState, rawValue: string): SubmitResult
   }
 
   if (state.argsPhase === "optional-edit") {
+    if (arg.required && parsed.value === undefined) {
+      return { kind: "error", message: `${arg.name} is required` };
+    }
+
     if (parsed.value === undefined) {
       delete state.collectedArgs[arg.name];
     } else {
@@ -385,9 +440,14 @@ export function handleOptionalListSelection(
   optionValue: unknown,
 ): {
   submit: boolean;
+  clearSaved: boolean;
 } {
   if (optionValue === SUBMIT_OPTION_VALUE) {
-    return { submit: true };
+    return { submit: true, clearSaved: false };
+  }
+
+  if (optionValue === CLEAR_SAVED_OPTION_VALUE) {
+    return { submit: false, clearSaved: true };
   }
 
   if (typeof optionValue === "string") {
@@ -395,7 +455,7 @@ export function handleOptionalListSelection(
     state.editingOptionalArgName = optionValue;
   }
 
-  return { submit: false };
+  return { submit: false, clearSaved: false };
 }
 
 export function isUnsetEnumValue(value: unknown): boolean {

--- a/src/tui/connection.ts
+++ b/src/tui/connection.ts
@@ -3,6 +3,8 @@ import { TerminalClient } from "../lib/client.ts";
 import { loadConfig, saveConfig } from "../lib/config.ts";
 import type { TuiContext } from "./types.ts";
 import { formatDate, sidebarSection } from "./format.ts";
+import { cancelArgsFlow } from "./args.ts";
+import { getConnectionScopeKey } from "./args-cache.ts";
 
 function safeString(val: unknown): string {
   if (val === null || val === undefined) return "N/A";
@@ -84,10 +86,14 @@ export function setActiveConnection(
 
   const newConfig = loadConfig(context.currentProfileName);
   context.client = new TerminalClient(newConfig);
+  context.argsCacheScopeKey = getConnectionScopeKey(token);
 
   context.state.connectionInfo = connection;
   updateConnectionDisplay(context);
   context.state.error = null;
+
+  cancelArgsFlow(context.state);
+  context.state.selectedCommand = null;
 
   const providerObj = connection["provider"] as Record<string, unknown> | undefined;
   const providerName = safeString(providerObj?.["name"]);

--- a/src/tui/handlers.ts
+++ b/src/tui/handlers.ts
@@ -70,7 +70,7 @@ function bindComponentHandlers(context: TuiContext): void {
 
     state.selectedCommand = cmd;
     state.error = null;
-    initArgsStateForCommand(state, cmd, context.argsCache);
+    initArgsStateForCommand(state, cmd, context.argsCache, context.argsCacheScopeKey);
 
     if (shouldPromptForArgs(cmd)) {
       state.currentView = "args";
@@ -104,7 +104,12 @@ function bindComponentHandlers(context: TuiContext): void {
     state.optionalArgIndex = index;
     const selection = handleOptionalListSelection(state, option.value);
     if (selection.clearSaved && state.selectedCommand) {
-      clearSavedArgsForCommand(state, state.selectedCommand, context.argsCache);
+      clearSavedArgsForCommand(
+        state,
+        state.selectedCommand,
+        context.argsCache,
+        context.argsCacheScopeKey,
+      );
       updateView(context);
       updateStatusBar(context);
       return;
@@ -201,9 +206,14 @@ function setupKeyHandlers(context: TuiContext): void {
       state.argsPhase === "optional-list" &&
       optionalArgsSelect.focused &&
       state.selectedCommand &&
-      hasCachedArgs(context.argsCache, state.selectedCommand.name)
+      hasCachedArgs(context.argsCache, context.argsCacheScopeKey, state.selectedCommand)
     ) {
-      clearSavedArgsForCommand(state, state.selectedCommand, context.argsCache);
+      clearSavedArgsForCommand(
+        state,
+        state.selectedCommand,
+        context.argsCache,
+        context.argsCacheScopeKey,
+      );
       updateView(context);
       updateStatusBar(context);
       return;

--- a/src/tui/handlers.ts
+++ b/src/tui/handlers.ts
@@ -9,6 +9,7 @@ import { findCommandByName, filterCommandOptions } from "./commands.ts";
 import { executeCommand } from "./actions.ts";
 import {
   cancelArgsFlow,
+  clearSavedArgsForCommand,
   handleOptionalListSelection,
   initArgsStateForCommand,
   isUnsetEnumValue,
@@ -16,6 +17,7 @@ import {
   submitActiveArg,
 } from "./args.ts";
 import { setActiveConnection } from "./connection.ts";
+import { hasCachedArgs } from "./args-cache.ts";
 import { filterResults, navigateDetailItem } from "./results.ts";
 import { updateStatusBar, updateView } from "./view.ts";
 import { copyToClipboard } from "./detail.ts";
@@ -68,7 +70,7 @@ function bindComponentHandlers(context: TuiContext): void {
 
     state.selectedCommand = cmd;
     state.error = null;
-    initArgsStateForCommand(state, cmd);
+    initArgsStateForCommand(state, cmd, context.argsCache);
 
     if (shouldPromptForArgs(cmd)) {
       state.currentView = "args";
@@ -101,6 +103,12 @@ function bindComponentHandlers(context: TuiContext): void {
   optionalArgsSelect.on(SelectRenderableEvents.ITEM_SELECTED, (index: number, option) => {
     state.optionalArgIndex = index;
     const selection = handleOptionalListSelection(state, option.value);
+    if (selection.clearSaved && state.selectedCommand) {
+      clearSavedArgsForCommand(state, state.selectedCommand, context.argsCache);
+      updateView(context);
+      updateStatusBar(context);
+      return;
+    }
     if (selection.submit && state.selectedCommand) {
       void executeCommand(context, state.selectedCommand);
       return;
@@ -184,6 +192,20 @@ function setupKeyHandlers(context: TuiContext): void {
       state.selectedCommand
     ) {
       void executeCommand(context, state.selectedCommand);
+      return;
+    }
+
+    if (
+      key.name === "d" &&
+      state.currentView === "args" &&
+      state.argsPhase === "optional-list" &&
+      optionalArgsSelect.focused &&
+      state.selectedCommand &&
+      hasCachedArgs(context.argsCache, state.selectedCommand.name)
+    ) {
+      clearSavedArgsForCommand(state, state.selectedCommand, context.argsCache);
+      updateView(context);
+      updateStatusBar(context);
       return;
     }
 

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -8,6 +8,7 @@ import type {
 } from "@opentui/core";
 import type { TerminalClient } from "../lib/client.ts";
 import type { AppState } from "./state.ts";
+import type { ArgsCache } from "./args-cache.ts";
 
 export interface UiComponents {
   commandSelect: SelectRenderable;
@@ -37,5 +38,6 @@ export interface TuiContext {
   client: TerminalClient;
   state: AppState;
   components: UiComponents;
+  argsCache: ArgsCache;
   currentProfileName?: string;
 }

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -39,5 +39,7 @@ export interface TuiContext {
   state: AppState;
   components: UiComponents;
   argsCache: ArgsCache;
+  /** Active connection token scope for args cache (see resolveArgsCacheScopeKey). */
+  argsCacheScopeKey: string;
   currentProfileName?: string;
 }

--- a/src/tui/view.ts
+++ b/src/tui/view.ts
@@ -1,6 +1,7 @@
 import { StyledText, dim, white } from "@opentui/core";
 import type { TuiContext } from "./types.ts";
 import { isConnectionsView } from "./constants.ts";
+import { hasCachedArgs } from "./args-cache.ts";
 import { getOptionalArgs, getRequiredArgs, updateArgsView } from "./args.ts";
 import { resultsToOptions } from "./results.ts";
 import { formatDetail } from "./detail.ts";
@@ -46,6 +47,9 @@ export function updateStatusBar(context: TuiContext): void {
         { key: "esc", action: "cancel" },
         { key: "ctrl+c", action: "quit" },
       ];
+      if (state.selectedCommand && hasCachedArgs(context.argsCache, state.selectedCommand.name)) {
+        hotkeys.splice(1, 0, { key: "d", action: "clear saved" });
+      }
     } else if (state.argsPhase === "optional-edit") {
       hotkeys = [
         { key: "enter", action: "save" },
@@ -163,7 +167,7 @@ export function updateView(context: TuiContext): void {
     const optionalArgs = state.selectedCommand ? getOptionalArgs(state.selectedCommand) : [];
 
     argsContainer.visible = true;
-    updateArgsView(state, components);
+    updateArgsView(state, components, context.argsCache);
 
     if (state.argsPhase === "required") {
       titleDisplay.content = `${cmdName} - Required ${state.currentArgIndex + 1}/${Math.max(1, requiredArgs.length)}`;

--- a/src/tui/view.ts
+++ b/src/tui/view.ts
@@ -47,7 +47,10 @@ export function updateStatusBar(context: TuiContext): void {
         { key: "esc", action: "cancel" },
         { key: "ctrl+c", action: "quit" },
       ];
-      if (state.selectedCommand && hasCachedArgs(context.argsCache, state.selectedCommand.name)) {
+      if (
+        state.selectedCommand &&
+        hasCachedArgs(context.argsCache, context.argsCacheScopeKey, state.selectedCommand)
+      ) {
         hotkeys.splice(1, 0, { key: "d", action: "clear saved" });
       }
     } else if (state.argsPhase === "optional-edit") {
@@ -167,7 +170,7 @@ export function updateView(context: TuiContext): void {
     const optionalArgs = state.selectedCommand ? getOptionalArgs(state.selectedCommand) : [];
 
     argsContainer.visible = true;
-    updateArgsView(state, components, context.argsCache);
+    updateArgsView(state, components, context.argsCache, context.argsCacheScopeKey);
 
     if (state.argsPhase === "required") {
       titleDisplay.content = `${cmdName} - Required ${state.currentArgIndex + 1}/${Math.max(1, requiredArgs.length)}`;

--- a/tests/tui-args-cache.test.ts
+++ b/tests/tui-args-cache.test.ts
@@ -5,9 +5,12 @@ import {
   clearCachedArgs,
   createArgsCache,
   getCachedArgs,
+  resolveArgsCacheScopeKey,
   saveArgsToCache,
 } from "../src/tui/args-cache.ts";
 import { initArgsStateForCommand } from "../src/tui/args.ts";
+
+const CONNECTION_SCOPE = "conn_a";
 
 function makeCommand(partial: Partial<Command>): Command {
   return {
@@ -27,21 +30,41 @@ describe("args cache", () => {
     const cache = createArgsCache();
     const cmd = makeCommand({
       name: "list-vehicles",
+      requiresConnectionToken: true,
       args: [
         { name: "limit", type: "number", required: false, description: "" },
         { name: "cursor", type: "string", required: false, description: "" },
       ],
     });
 
-    saveArgsToCache(cache, cmd, { limit: 50, cursor: "page_2" });
+    saveArgsToCache(cache, CONNECTION_SCOPE, cmd, { limit: 50, cursor: "page_2" });
 
-    expect(getCachedArgs(cache, cmd)).toEqual({ limit: 50 });
+    expect(getCachedArgs(cache, CONNECTION_SCOPE, cmd)).toEqual({ limit: 50 });
+  });
+
+  test("account-level commands use global scope regardless of connection", () => {
+    const cache = createArgsCache();
+    const cmd = makeCommand({
+      name: "list-connections",
+      requiresConnectionToken: false,
+      args: [{ name: "limit", type: "number", required: false, description: "" }],
+    });
+
+    expect(resolveArgsCacheScopeKey(cmd, "conn_a")).toBe("");
+
+    saveArgsToCache(cache, "conn_a", cmd, { limit: 25 });
+    saveArgsToCache(cache, "conn_b", cmd, { limit: 50 });
+
+    expect(getCachedArgs(cache, "conn_a", cmd)).toEqual({ limit: 50 });
+    expect(getCachedArgs(cache, "conn_b", cmd)).toEqual({ limit: 50 });
+    expect(getCachedArgs(cache, "", cmd)).toEqual({ limit: 50 });
   });
 
   test("drops invalid enum values on restore", () => {
     const cache = createArgsCache();
     const cmd = makeCommand({
       name: "list-vehicles",
+      requiresConnectionToken: true,
       args: [
         {
           name: "expand",
@@ -53,38 +76,56 @@ describe("args cache", () => {
       ],
     });
 
-    cache.set("list-vehicles", { expand: "invalid" });
-    expect(getCachedArgs(cache, cmd)).toEqual({});
+    cache.set(`${CONNECTION_SCOPE}\0list-vehicles`, { expand: "invalid" });
+    expect(getCachedArgs(cache, CONNECTION_SCOPE, cmd)).toEqual({});
   });
 
   test("clearCachedArgs removes command entry", () => {
     const cache = createArgsCache();
     const cmd = makeCommand({
       name: "get-vehicle",
+      requiresConnectionToken: true,
       args: [{ name: "id", type: "string", required: true, description: "" }],
     });
 
-    saveArgsToCache(cache, cmd, { id: "vcl_123" });
-    clearCachedArgs(cache, cmd.name);
+    saveArgsToCache(cache, CONNECTION_SCOPE, cmd, { id: "vcl_123" });
+    clearCachedArgs(cache, CONNECTION_SCOPE, cmd);
 
-    expect(getCachedArgs(cache, cmd)).toEqual({});
+    expect(getCachedArgs(cache, CONNECTION_SCOPE, cmd)).toEqual({});
+  });
+
+  test("cache is isolated per connection scope for connection commands", () => {
+    const cache = createArgsCache();
+    const cmd = makeCommand({
+      name: "get-vehicle",
+      requiresConnectionToken: true,
+      args: [{ name: "id", type: "string", required: true, description: "" }],
+    });
+
+    saveArgsToCache(cache, "conn_a", cmd, { id: "vcl_a" });
+    saveArgsToCache(cache, "conn_b", cmd, { id: "vcl_b" });
+
+    expect(getCachedArgs(cache, "conn_a", cmd)).toEqual({ id: "vcl_a" });
+    expect(getCachedArgs(cache, "conn_b", cmd)).toEqual({ id: "vcl_b" });
+    expect(getCachedArgs(cache, "conn_c", cmd)).toEqual({});
   });
 
   test("initArgsStateForCommand restores cache and skips to optional-list", () => {
     const cache = createArgsCache();
     const cmd = makeCommand({
       name: "get-vehicle",
+      requiresConnectionToken: true,
       args: [
         { name: "id", type: "string", required: true, description: "" },
         { name: "expand", type: "string", required: false, description: "" },
       ],
     });
 
-    saveArgsToCache(cache, cmd, { id: "vcl_123", expand: "groups" });
+    saveArgsToCache(cache, CONNECTION_SCOPE, cmd, { id: "vcl_123", expand: "groups" });
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd, cache);
+    initArgsStateForCommand(state, cmd, cache, CONNECTION_SCOPE);
 
     expect(state.collectedArgs).toEqual({ id: "vcl_123", expand: "groups" });
     expect(state.argsPhase).toBe("optional-list");
@@ -94,17 +135,18 @@ describe("args cache", () => {
     const cache = createArgsCache();
     const cmd = makeCommand({
       name: "get-vehicle",
+      requiresConnectionToken: true,
       args: [
         { name: "id", type: "string", required: true, description: "" },
         { name: "vehicleId", type: "string", required: true, description: "" },
       ],
     });
 
-    saveArgsToCache(cache, cmd, { id: "vcl_123" });
+    saveArgsToCache(cache, CONNECTION_SCOPE, cmd, { id: "vcl_123" });
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd, cache);
+    initArgsStateForCommand(state, cmd, cache, CONNECTION_SCOPE);
 
     expect(state.argsPhase).toBe("required");
     expect(state.currentArgIndex).toBe(1);

--- a/tests/tui-args-cache.test.ts
+++ b/tests/tui-args-cache.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import type { Command } from "../generated/index.ts";
+import { createInitialState } from "../src/tui/state.ts";
+import {
+  clearCachedArgs,
+  createArgsCache,
+  getCachedArgs,
+  saveArgsToCache,
+} from "../src/tui/args-cache.ts";
+import { initArgsStateForCommand } from "../src/tui/args.ts";
+
+function makeCommand(partial: Partial<Command>): Command {
+  return {
+    name: partial.name ?? "test",
+    description: partial.description ?? "",
+    method: partial.method ?? "POST",
+    path: partial.path ?? "/test",
+    requiresConnectionToken: partial.requiresConnectionToken ?? false,
+    args: partial.args ?? [],
+    handler: partial.handler ?? (async () => ({})),
+    responseSchema: partial.responseSchema ?? null,
+  };
+}
+
+describe("args cache", () => {
+  test("save and restore cacheable args per command", () => {
+    const cache = createArgsCache();
+    const cmd = makeCommand({
+      name: "list-vehicles",
+      args: [
+        { name: "limit", type: "number", required: false, description: "" },
+        { name: "cursor", type: "string", required: false, description: "" },
+      ],
+    });
+
+    saveArgsToCache(cache, cmd, { limit: 50, cursor: "page_2" });
+
+    expect(getCachedArgs(cache, cmd)).toEqual({ limit: 50 });
+  });
+
+  test("drops invalid enum values on restore", () => {
+    const cache = createArgsCache();
+    const cmd = makeCommand({
+      name: "list-vehicles",
+      args: [
+        {
+          name: "expand",
+          type: "string",
+          required: false,
+          description: "",
+          enum: ["groups", "devices"],
+        },
+      ],
+    });
+
+    cache.set("list-vehicles", { expand: "invalid" });
+    expect(getCachedArgs(cache, cmd)).toEqual({});
+  });
+
+  test("clearCachedArgs removes command entry", () => {
+    const cache = createArgsCache();
+    const cmd = makeCommand({
+      name: "get-vehicle",
+      args: [{ name: "id", type: "string", required: true, description: "" }],
+    });
+
+    saveArgsToCache(cache, cmd, { id: "vcl_123" });
+    clearCachedArgs(cache, cmd.name);
+
+    expect(getCachedArgs(cache, cmd)).toEqual({});
+  });
+
+  test("initArgsStateForCommand restores cache and skips to optional-list", () => {
+    const cache = createArgsCache();
+    const cmd = makeCommand({
+      name: "get-vehicle",
+      args: [
+        { name: "id", type: "string", required: true, description: "" },
+        { name: "expand", type: "string", required: false, description: "" },
+      ],
+    });
+
+    saveArgsToCache(cache, cmd, { id: "vcl_123", expand: "groups" });
+
+    const state = createInitialState();
+    state.selectedCommand = cmd;
+    initArgsStateForCommand(state, cmd, cache);
+
+    expect(state.collectedArgs).toEqual({ id: "vcl_123", expand: "groups" });
+    expect(state.argsPhase).toBe("optional-list");
+  });
+
+  test("initArgsStateForCommand prompts for missing required args", () => {
+    const cache = createArgsCache();
+    const cmd = makeCommand({
+      name: "get-vehicle",
+      args: [
+        { name: "id", type: "string", required: true, description: "" },
+        { name: "vehicleId", type: "string", required: true, description: "" },
+      ],
+    });
+
+    saveArgsToCache(cache, cmd, { id: "vcl_123" });
+
+    const state = createInitialState();
+    state.selectedCommand = cmd;
+    initArgsStateForCommand(state, cmd, cache);
+
+    expect(state.argsPhase).toBe("required");
+    expect(state.currentArgIndex).toBe(1);
+    expect(state.collectedArgs.id).toBe("vcl_123");
+  });
+});

--- a/tests/tui-args.test.ts
+++ b/tests/tui-args.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { Command } from "../generated/index.ts";
 import { createInitialState } from "../src/tui/state.ts";
+import { createArgsCache } from "../src/tui/args-cache.ts";
 import {
   buildOptionalArgsOptions,
   formatCollectedArgValue,
@@ -33,7 +34,7 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd);
+    initArgsStateForCommand(state, cmd, createArgsCache());
 
     expect(state.argsPhase as string).toBe("optional-list");
   });
@@ -48,7 +49,7 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd);
+    initArgsStateForCommand(state, cmd, createArgsCache());
 
     expect(state.argsPhase).toBe("required");
 
@@ -68,7 +69,7 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd);
+    initArgsStateForCommand(state, cmd, createArgsCache());
 
     state.argsPhase = "optional-edit";
     state.editingOptionalArgName = "days";
@@ -92,10 +93,11 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd);
+    initArgsStateForCommand(state, cmd, createArgsCache());
 
     const res = handleOptionalListSelection(state, "startFrom");
     expect(res.submit).toBe(false);
+    expect(res.clearSaved).toBe(false);
     expect(state.argsPhase).toBe("optional-edit");
     expect(state.editingOptionalArgName).toBe("startFrom");
   });
@@ -107,10 +109,11 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd);
+    initArgsStateForCommand(state, cmd, createArgsCache());
 
     const res = handleOptionalListSelection(state, "__submit__");
     expect(res.submit).toBe(true);
+    expect(res.clearSaved).toBe(false);
   });
 
   test("formatCollectedArgValue renders compact previews", () => {
@@ -131,11 +134,11 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd);
+    initArgsStateForCommand(state, cmd, createArgsCache());
     state.collectedArgs.startedAfter = "2024-01-01T00:00:00Z";
     state.collectedArgs.raw = true;
 
-    const options = buildOptionalArgsOptions(cmd, state);
+    const options = buildOptionalArgsOptions(cmd, state, createArgsCache());
     const startedAfter = options.find((option) => option.value === "startedAfter");
     const raw = options.find((option) => option.value === "raw");
     const unset = options.find((option) => option.value === "startFrom");

--- a/tests/tui-args.test.ts
+++ b/tests/tui-args.test.ts
@@ -34,7 +34,7 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd, createArgsCache());
+    initArgsStateForCommand(state, cmd, createArgsCache(), "");
 
     expect(state.argsPhase as string).toBe("optional-list");
   });
@@ -49,7 +49,7 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd, createArgsCache());
+    initArgsStateForCommand(state, cmd, createArgsCache(), "");
 
     expect(state.argsPhase).toBe("required");
 
@@ -69,7 +69,7 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd, createArgsCache());
+    initArgsStateForCommand(state, cmd, createArgsCache(), "");
 
     state.argsPhase = "optional-edit";
     state.editingOptionalArgName = "days";
@@ -93,7 +93,7 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd, createArgsCache());
+    initArgsStateForCommand(state, cmd, createArgsCache(), "");
 
     const res = handleOptionalListSelection(state, "startFrom");
     expect(res.submit).toBe(false);
@@ -109,7 +109,7 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd, createArgsCache());
+    initArgsStateForCommand(state, cmd, createArgsCache(), "");
 
     const res = handleOptionalListSelection(state, "__submit__");
     expect(res.submit).toBe(true);
@@ -134,11 +134,11 @@ describe("tui args flow", () => {
 
     const state = createInitialState();
     state.selectedCommand = cmd;
-    initArgsStateForCommand(state, cmd, createArgsCache());
+    initArgsStateForCommand(state, cmd, createArgsCache(), "");
     state.collectedArgs.startedAfter = "2024-01-01T00:00:00Z";
     state.collectedArgs.raw = true;
 
-    const options = buildOptionalArgsOptions(cmd, state, createArgsCache());
+    const options = buildOptionalArgsOptions(cmd, state, createArgsCache(), "");
     const startedAfter = options.find((option) => option.value === "startedAfter");
     const raw = options.find((option) => option.value === "raw");
     const unset = options.find((option) => option.value === "startFrom");


### PR DESCRIPTION
So that repeated queries within a session remember the params you set last time, scoped to the active connection where appropriate